### PR TITLE
Added webhook type of build completed event

### DIFF
--- a/core/webhook.go
+++ b/core/webhook.go
@@ -27,11 +27,12 @@ const (
 
 // Webhook action types.
 const (
-	WebhookActionCreated  = "created"
-	WebhookActionUpdated  = "updated"
-	WebhookActionDeleted  = "deleted"
-	WebhookActionEnabled  = "enabled"
-	WebhookActionDisabled = "disabled"
+	WebhookActionCreated   = "created"
+	WebhookActionUpdated   = "updated"
+	WebhookActionDeleted   = "deleted"
+	WebhookActionEnabled   = "enabled"
+	WebhookActionDisabled  = "disabled"
+	WebhookActionCompleted = "completed"
 )
 
 type (

--- a/operator/manager/teardown.go
+++ b/operator/manager/teardown.go
@@ -174,9 +174,21 @@ func (t *teardown) do(ctx context.Context, stage *core.Stage) error {
 		Repo:   repo,
 		Build:  build,
 	}
+
 	err = t.Webhook.Send(noContext, payload)
 	if err != nil {
-		logger.WithError(err).Warnln("manager: cannot send global webhook")
+		logger.WithError(err).Warnln("manager: cannot send global WebhookActionUpdated webhook")
+	}
+
+	payload = &core.WebhookData{
+		Event:  core.WebhookEventBuild,
+		Action: core.WebhookActionCompleted,
+		Repo:   repo,
+		Build:  build,
+	}
+	err = t.Webhook.Send(noContext, payload)
+	if err != nil {
+		logger.WithError(err).Warnln("manager: cannot send global WebhookActionCompleted webhook")
 	}
 
 	user, err := t.Users.Find(noContext, repo.UserID)


### PR DESCRIPTION
Currently when the build/stage is completed, "updated" type of the webhook is fired.
"updated" type of web hook is not being removed, not to break any existing integrations and additional "completed" web hook is introduced, which would help to identify for the webhook receivers, when actually the build ended

Issue: https://github.com/drone/drone/issues/2921