### PR TITLE
Allow to configure TLS versions and ciphers

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -239,15 +239,19 @@ type (
 
 	// Server provides the server configuration.
 	Server struct {
-		Addr  string `envconfig:"-"`
-		Host  string `envconfig:"DRONE_SERVER_HOST" default:"localhost:8080"`
-		Port  string `envconfig:"DRONE_SERVER_PORT" default:":8080"`
-		Proto string `envconfig:"DRONE_SERVER_PROTO" default:"http"`
-		Pprof bool   `envconfig:"DRONE_PPROF_ENABLED"`
-		Acme  bool   `envconfig:"DRONE_TLS_AUTOCERT"`
-		Email string `envconfig:"DRONE_TLS_EMAIL"`
-		Cert  string `envconfig:"DRONE_TLS_CERT"`
-		Key   string `envconfig:"DRONE_TLS_KEY"`
+		Addr            string   `envconfig:"-"`
+		Host            string   `envconfig:"DRONE_SERVER_HOST" default:"localhost:8080"`
+		Port            string   `envconfig:"DRONE_SERVER_PORT" default:":8080"`
+		Proto           string   `envconfig:"DRONE_SERVER_PROTO" default:"http"`
+		Pprof           bool     `envconfig:"DRONE_PPROF_ENABLED"`
+		Acme            bool     `envconfig:"DRONE_TLS_AUTOCERT"`
+		Email           string   `envconfig:"DRONE_TLS_EMAIL"`
+		Cert            string   `envconfig:"DRONE_TLS_CERT"`
+		Key             string   `envconfig:"DRONE_TLS_KEY"`
+		TLSMinVersion   string   `envconfig:"DRONE_TLS_MIN_VERSION"`
+		TLSMaxVersion   string   `envconfig:"DRONE_TLS_MAX_VERSION"`
+		TLSCurves       []string `envconfig:"DRONE_TLS_CURVES"`
+		TLSCipherSuites []string `envconfig:"DRONE_TLS_CIPHER_SUITES"`
 	}
 
 	// Proxy provides proxy server configuration.

--- a/cmd/drone-server/inject_server.go
+++ b/cmd/drone-server/inject_server.go
@@ -115,12 +115,16 @@ func provideRPC2(m manager.BuildManager, config config.Config) rpcHandlerV2 {
 // http server that is configured from the environment.
 func provideServer(handler *chi.Mux, config config.Config) *server.Server {
 	return &server.Server{
-		Acme:    config.Server.Acme,
-		Addr:    config.Server.Port,
-		Cert:    config.Server.Cert,
-		Key:     config.Server.Key,
-		Host:    config.Server.Host,
-		Handler: handler,
+		Acme:            config.Server.Acme,
+		Addr:            config.Server.Port,
+		Cert:            config.Server.Cert,
+		Key:             config.Server.Key,
+		Host:            config.Server.Host,
+		TLSMinVersion:   config.Server.TLSMinVersion,
+		TLSMaxVersion:   config.Server.TLSMaxVersion,
+		TLSCurves:       config.Server.TLSCurves,
+		TLSCipherSuites: config.Server.TLSCipherSuites,
+		Handler:         handler,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -25,15 +26,102 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+var (
+	tlsVersion = map[string]uint16{
+		"TLS10": tls.VersionTLS10,
+		"TLS11": tls.VersionTLS11,
+		"TLS12": tls.VersionTLS12,
+		"TLS13": tls.VersionTLS13,
+	}
+
+	tlsCurve = map[string]tls.CurveID{
+		"CurveP256": tls.CurveP256,
+		"CurveP384": tls.CurveP384,
+		"CurveP521": tls.CurveP521,
+		"X25519":    tls.X25519,
+	}
+
+	tlsCipher = map[string]uint16{
+		"RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+		"RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		"ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		"ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		"AES_128_GCM_SHA256":                  tls.TLS_AES_128_GCM_SHA256,
+		"AES_256_GCM_SHA384":                  tls.TLS_AES_256_GCM_SHA384,
+		"CHACHA20_POLY1305_SHA256":            tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+)
+
 // A Server defines parameters for running an HTTP server.
 type Server struct {
-	Acme    bool
-	Email   string
-	Addr    string
-	Cert    string
-	Key     string
-	Host    string
-	Handler http.Handler
+	Acme            bool
+	Email           string
+	Addr            string
+	Cert            string
+	Key             string
+	Host            string
+	TLSMinVersion   string
+	TLSMaxVersion   string
+	TLSCurves       []string
+	TLSCipherSuites []string
+	Handler         http.Handler
+}
+
+func (s Server) buildTLSConfig() (*tls.Config, error) {
+	cfg := &tls.Config{}
+	cfg.PreferServerCipherSuites = true
+	cfg.NextProtos = []string{"h2", "http/1.1"}
+	if s.TLSMinVersion != "" {
+		if version, found := tlsVersion[s.TLSMinVersion]; found {
+			cfg.MinVersion = version
+		} else {
+			return nil, fmt.Errorf("Unknown TLS min version: %s", s.TLSMinVersion)
+		}
+	}
+	if s.TLSMaxVersion != "" {
+		if version, found := tlsVersion[s.TLSMaxVersion]; found {
+			cfg.MaxVersion = version
+		} else {
+			return nil, fmt.Errorf("Unknown TLS max version: %s", s.TLSMaxVersion)
+		}
+	}
+	for _, curve := range s.TLSCurves {
+		if curve != "" {
+			if curveId, found := tlsCurve[curve]; found {
+				cfg.CurvePreferences = append(cfg.CurvePreferences, curveId)
+			} else {
+				return nil, fmt.Errorf("Unknown TLS curve: %s", curve)
+			}
+		}
+	}
+	for _, cipher := range s.TLSCipherSuites {
+		if cipher != "" {
+			if cipherId, found := tlsCipher[cipher]; found {
+				cfg.CipherSuites = append(cfg.CipherSuites, cipherId)
+			} else {
+				return nil, fmt.Errorf("Unknown TLS cipher: %s", cipher)
+			}
+		}
+	}
+	return cfg, nil
 }
 
 // ListenAndServe initializes a server to respond to HTTP network requests.
@@ -66,13 +154,19 @@ func (s Server) listenAndServe(ctx context.Context) error {
 
 func (s Server) listenAndServeTLS(ctx context.Context) error {
 	var g errgroup.Group
+
+	cfg, err := s.buildTLSConfig()
+	if err != nil {
+		return err
+	}
 	s1 := &http.Server{
 		Addr:    ":http",
 		Handler: http.HandlerFunc(redirect),
 	}
 	s2 := &http.Server{
-		Addr:    ":https",
-		Handler: s.Handler,
+		Addr:      ":https",
+		Handler:   s.Handler,
+		TLSConfig: cfg,
 	}
 	g.Go(func() error {
 		return s1.ListenAndServe()
@@ -97,6 +191,10 @@ func (s Server) listenAndServeTLS(ctx context.Context) error {
 func (s Server) listenAndServeAcme(ctx context.Context) error {
 	var g errgroup.Group
 
+	cfg, err := s.buildTLSConfig()
+	if err != nil {
+		return err
+	}
 	c := cacheDir()
 	m := &autocert.Manager{
 		Email:      s.Email,
@@ -108,14 +206,11 @@ func (s Server) listenAndServeAcme(ctx context.Context) error {
 		Addr:    ":http",
 		Handler: m.HTTPHandler(s.Handler),
 	}
+	cfg.GetCertificate = m.GetCertificate
 	s2 := &http.Server{
-		Addr:    ":https",
-		Handler: s.Handler,
-		TLSConfig: &tls.Config{
-			GetCertificate: m.GetCertificate,
-			NextProtos:     []string{"h2", "http/1.1"},
-			MinVersion:     tls.VersionTLS12,
-		},
+		Addr:      ":https",
+		Handler:   s.Handler,
+		TLSConfig: cfg,
 	}
 	g.Go(func() error {
 		return s1.ListenAndServe()

--- a/server/server.go
+++ b/server/server.go
@@ -67,6 +67,7 @@ var (
 		"AES_128_GCM_SHA256":                  tls.TLS_AES_128_GCM_SHA256,
 		"AES_256_GCM_SHA384":                  tls.TLS_AES_256_GCM_SHA384,
 		"CHACHA20_POLY1305_SHA256":            tls.TLS_CHACHA20_POLY1305_SHA256,
+		"FALLBACK_SCSV":                       tls.TLS_FALLBACK_SCSV,
 	}
 )
 


### PR DESCRIPTION
This patch uses 4 new envs:

- `DRONE_TLS_MIN_VERSION` minimum TLS version that is acceptable
- `DRONE_TLS_MAX_VERSION` the maximum TLS version that is acceptable
- `DRONE_TLS_CURVES` list of elliptic curves that will be used in an ECDHE handshake
- `DRONE_TLS_CIPHER_SUITES` list of supported cipher suites 

For example:
```
DRONE_TLS_MIN_VERSION="TLS12"
DRONE_TLS_CURVES="CurveP256,X25519"
DRONE_TLS_CIPHER_SUITES="ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,ECDHE_RSA_WITH_AES_256_GCM_SHA384,ECDHE_ECDSA_WITH_CHACHA20_POLY1305,ECDHE_RSA_WITH_CHACHA20_POLY1305,ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,ECDHE_RSA_WITH_AES_128_GCM_SHA256"
```