### PR TITLE
feat: delete scm webhook when disable repo.

### DIFF
--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -183,7 +183,7 @@ func (s Server) Handler() http.Handler {
 			).Post("/", repos.HandleEnable(s.Hooks, s.Repos, s.Webhook))
 			r.With(
 				acl.CheckAdminAccess(),
-			).Delete("/", repos.HandleDisable(s.Hooks, s.Repos, s.Webhook))
+			).Delete("/", repos.HandleDisable(s.Users, s.Hooks, s.Repos, s.Webhook))
 			r.With(
 				acl.CheckAdminAccess(),
 			).Post("/chown", repos.HandleChown(s.Repos))

--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -183,7 +183,7 @@ func (s Server) Handler() http.Handler {
 			).Post("/", repos.HandleEnable(s.Hooks, s.Repos, s.Webhook))
 			r.With(
 				acl.CheckAdminAccess(),
-			).Delete("/", repos.HandleDisable(s.Repos, s.Webhook))
+			).Delete("/", repos.HandleDisable(s.Hooks, s.Repos, s.Webhook))
 			r.With(
 				acl.CheckAdminAccess(),
 			).Post("/chown", repos.HandleChown(s.Repos))

--- a/handler/api/repos/disable.go
+++ b/handler/api/repos/disable.go
@@ -15,6 +15,7 @@
 package repos
 
 import (
+	"github.com/drone/drone/handler/api/request"
 	"net/http"
 
 	"github.com/drone/drone/core"
@@ -27,6 +28,7 @@ import (
 // HandleDisable returns an http.HandlerFunc that processes http
 // requests to disable a repository in the system.
 func HandleDisable(
+	hooks core.HookService,
 	repos core.RepositoryStore,
 	sender core.WebhookSender,
 ) http.HandlerFunc {
@@ -36,6 +38,7 @@ func HandleDisable(
 			name  = chi.URLParam(r, "name")
 		)
 
+		user, _ := request.UserFrom(r.Context())
 		repo, err := repos.FindName(r.Context(), owner, name)
 		if err != nil {
 			render.NotFound(w, err)
@@ -47,6 +50,18 @@ func HandleDisable(
 			return
 		}
 		repo.Active = false
+
+		err = hooks.Delete(r.Context(), user, repo)
+		if err != nil {
+			render.InternalError(w, err)
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", owner).
+				WithField("name", name).
+				Debugln("api: cannot delete hook")
+			return
+		}
+
 		err = repos.Update(r.Context(), repo)
 		if err != nil {
 			render.InternalError(w, err)

--- a/handler/api/repos/disable.go
+++ b/handler/api/repos/disable.go
@@ -51,17 +51,6 @@ func HandleDisable(
 		}
 		repo.Active = false
 
-		err = hooks.Delete(r.Context(), user, repo)
-		if err != nil {
-			render.InternalError(w, err)
-			logger.FromRequest(r).
-				WithError(err).
-				WithField("namespace", owner).
-				WithField("name", name).
-				Debugln("api: cannot delete hook")
-			return
-		}
-
 		err = repos.Update(r.Context(), repo)
 		if err != nil {
 			render.InternalError(w, err)
@@ -71,6 +60,15 @@ func HandleDisable(
 				WithField("name", name).
 				Warnln("api: cannot update repository")
 			return
+		}
+
+		err = hooks.Delete(r.Context(), user, repo)
+		if err != nil {
+			logger.FromRequest(r).
+				WithError(err).
+				WithField("namespace", owner).
+				WithField("name", name).
+				Warnln("api: cannot delete hook")
 		}
 
 		action := core.WebhookActionDisabled

--- a/handler/api/repos/disable.go
+++ b/handler/api/repos/disable.go
@@ -28,6 +28,7 @@ import (
 // HandleDisable returns an http.HandlerFunc that processes http
 // requests to disable a repository in the system.
 func HandleDisable(
+	users core.UserStore,
 	hooks core.HookService,
 	repos core.RepositoryStore,
 	sender core.WebhookSender,
@@ -50,6 +51,12 @@ func HandleDisable(
 			return
 		}
 		repo.Active = false
+
+		_, err = users.Find(r.Context(), repo.UserID)
+		if err != nil {
+			render.NotFound(w, err)
+			return
+		}
 
 		err = repos.Update(r.Context(), repo)
 		if err != nil {

--- a/handler/api/repos/disable_test.go
+++ b/handler/api/repos/disable_test.go
@@ -32,6 +32,9 @@ func TestDisable(t *testing.T) {
 		Active:    true,
 	}
 
+	service := mock.NewMockHookService(controller)
+	service.EXPECT().Delete(gomock.Any(), gomock.Any(), repo).Return(nil)
+
 	repos := mock.NewMockRepositoryStore(controller)
 	repos.EXPECT().FindName(gomock.Any(), gomock.Any(), repo.Name).Return(repo, nil)
 	repos.EXPECT().Update(gomock.Any(), repo).Return(nil)
@@ -45,7 +48,7 @@ func TestDisable(t *testing.T) {
 	r := httptest.NewRequest("DELETE", "/api/repos/octocat/hello-world", nil)
 
 	router := chi.NewRouter()
-	router.Delete("/api/repos/{owner}/{name}", HandleDisable(repos, webhook))
+	router.Delete("/api/repos/{owner}/{name}", HandleDisable(service, repos, webhook))
 	router.ServeHTTP(w, r)
 
 	if got, want := w.Code, 200; want != got {
@@ -74,7 +77,7 @@ func TestDisable_NotFound(t *testing.T) {
 	r := httptest.NewRequest("DELETE", "/api/repos/octocat/hello-world", nil)
 
 	router := chi.NewRouter()
-	router.Delete("/api/repos/{owner}/{name}", HandleDisable(repos, nil))
+	router.Delete("/api/repos/{owner}/{name}", HandleDisable(nil, repos, nil))
 	router.ServeHTTP(w, r)
 
 	if got, want := w.Code, 404; want != got {
@@ -100,6 +103,9 @@ func TestDisable_InternalError(t *testing.T) {
 		Active:    false,
 	}
 
+	service := mock.NewMockHookService(controller)
+	service.EXPECT().Delete(gomock.Any(), gomock.Any(), repo).Return(nil)
+
 	repos := mock.NewMockRepositoryStore(controller)
 	repos.EXPECT().FindName(gomock.Any(), gomock.Any(), repo.Name).Return(repo, nil)
 	repos.EXPECT().Update(gomock.Any(), repo).Return(errors.ErrNotFound)
@@ -108,7 +114,7 @@ func TestDisable_InternalError(t *testing.T) {
 	r := httptest.NewRequest("DELETE", "/api/repos/octocat/hello-world", nil)
 
 	router := chi.NewRouter()
-	router.Delete("/api/repos/{owner}/{name}", HandleDisable(repos, nil))
+	router.Delete("/api/repos/{owner}/{name}", HandleDisable(service, repos, nil))
 	router.ServeHTTP(w, r)
 
 	if got, want := w.Code, http.StatusInternalServerError; want != got {
@@ -134,6 +140,9 @@ func TestDelete(t *testing.T) {
 		Active:    true,
 	}
 
+	service := mock.NewMockHookService(controller)
+	service.EXPECT().Delete(gomock.Any(), gomock.Any(), repo).Return(nil)
+
 	repos := mock.NewMockRepositoryStore(controller)
 	repos.EXPECT().FindName(gomock.Any(), gomock.Any(), repo.Name).Return(repo, nil)
 	repos.EXPECT().Update(gomock.Any(), repo).Return(nil)
@@ -148,7 +157,7 @@ func TestDelete(t *testing.T) {
 	r := httptest.NewRequest("DELETE", "/api/repos/octocat/hello-world?remove=true", nil)
 
 	router := chi.NewRouter()
-	router.Delete("/api/repos/{owner}/{name}", HandleDisable(repos, webhook))
+	router.Delete("/api/repos/{owner}/{name}", HandleDisable(service, repos, webhook))
 	router.ServeHTTP(w, r)
 
 	if got, want := w.Code, 200; want != got {

--- a/handler/api/repos/disable_test.go
+++ b/handler/api/repos/disable_test.go
@@ -104,7 +104,6 @@ func TestDisable_InternalError(t *testing.T) {
 	}
 
 	service := mock.NewMockHookService(controller)
-	service.EXPECT().Delete(gomock.Any(), gomock.Any(), repo).Return(nil)
 
 	repos := mock.NewMockRepositoryStore(controller)
 	repos.EXPECT().FindName(gomock.Any(), gomock.Any(), repo.Name).Return(repo, nil)


### PR DESCRIPTION
when disable repo, drone delete scm webhook.

for this issue: https://discourse.drone.io/t/disabling-repo-on-drone-does-not-delete-webhook/5146