### PR TITLE
Execute all convert plugins every time.

### DIFF
--- a/plugin/converter/combine.go
+++ b/plugin/converter/combine.go
@@ -42,7 +42,7 @@ func (c *combined) Convert(ctx context.Context, req *core.ConvertArgs) (*core.Co
 		if config.Data == "" {
 			continue
 		}
-		return config, nil
+		req.Config = config
 	}
 	return req.Config, nil
 }


### PR DESCRIPTION
Our use-case is that we are using the built-in jsonnet functionality AND the [paths-changed extension](https://github.com/meltwater/drone-convert-pathschanged).

The jsonnet is working well, but the second extension is never getting called. This allows all convert plugins to be executed, even if an earlier one returns a valid config. This lets you chain together multiple conversion plugins.

In the future, I'd like to extend this further to support multiple remote extensions, each with their own secrets. But for now, this would unblock the workflow I want to do.

See https://discourse.drone.io/t/multiple-configuration-extensions/7724