### PR TITLE
Fix image secrets in OSS version

### DIFF
--- a/operator/runner/runner.go
+++ b/operator/runner/runner.go
@@ -247,7 +247,7 @@ func (r *Runner) Run(ctx context.Context, id int64) error {
 		r.Secrets,
 	)
 	registryService := registry.Combine(
-		registry.Static(m.Secrets),
+		registry.Static(secretService),
 		r.Registry,
 	)
 


### PR DESCRIPTION
This fixes the finding of image pull secrets in OSS version. The
relevant secrets are not found because Drone doesn't parse encrypted
secrets for the registry.

The bug is reported here: https://discourse.drone.io/t/pulling-private-images-not-working-in-oss-version/7594

