### PR TITLE
Allow filtering builds by event

### DIFF
--- a/core/build.go
+++ b/core/build.go
@@ -67,10 +67,7 @@ type BuildStore interface {
 	FindRef(context.Context, int64, string) (*Build, error)
 
 	// List returns a list of builds from the datastore by repository id.
-	List(context.Context, int64, int, int) ([]*Build, error)
-
-	// ListRef returns a list of builds from the datastore by ref.
-	ListRef(context.Context, int64, string, int, int) ([]*Build, error)
+	List(context.Context, int64, string, string, int, int) ([]*Build, error)
 
 	// LatestBranches returns the latest builds from the
 	// datastore by branch.

--- a/handler/api/repos/builds/list.go
+++ b/handler/api/repos/builds/list.go
@@ -37,6 +37,7 @@ func HandleList(
 			namespace = chi.URLParam(r, "owner")
 			name      = chi.URLParam(r, "name")
 			branch    = r.FormValue("branch")
+			event     = r.FormValue("event")
 			page      = r.FormValue("page")
 			perPage   = r.FormValue("per_page")
 		)
@@ -63,12 +64,11 @@ func HandleList(
 		}
 
 		var results []*core.Build
+		ref := ""
 		if branch != "" {
-			ref := fmt.Sprintf("refs/heads/%s", branch)
-			results, err = builds.ListRef(r.Context(), repo.ID, ref, limit, offset)
-		} else {
-			results, err = builds.List(r.Context(), repo.ID, limit, offset)
+			ref = fmt.Sprintf("refs/heads/%s", branch)
 		}
+		results, err = builds.List(r.Context(), repo.ID, ref, event, limit, offset)
 
 		if err != nil {
 			render.InternalError(w, err)

--- a/handler/api/repos/builds/list_test.go
+++ b/handler/api/repos/builds/list_test.go
@@ -83,7 +83,7 @@ func TestList(t *testing.T) {
 	repos.EXPECT().FindName(gomock.Any(), gomock.Any(), mockRepo.Name).Return(mockRepo, nil)
 
 	builds := mock.NewMockBuildStore(controller)
-	builds.EXPECT().List(gomock.Any(), mockRepo.ID, 25, 0).Return(mockBuilds, nil)
+	builds.EXPECT().List(gomock.Any(), mockRepo.ID, "", "", 25, 0).Return(mockBuilds, nil)
 
 	c := new(chi.Context)
 	c.URLParams.Add("owner", "octocat")
@@ -115,14 +115,14 @@ func TestListBranch(t *testing.T) {
 	repos.EXPECT().FindName(gomock.Any(), gomock.Any(), mockRepo.Name).Return(mockRepo, nil)
 
 	builds := mock.NewMockBuildStore(controller)
-	builds.EXPECT().ListRef(gomock.Any(), mockRepo.ID, "refs/heads/develop", 25, 0).Return(mockBuilds, nil)
+	builds.EXPECT().List(gomock.Any(), mockRepo.ID, "refs/heads/develop", "cron", 25, 0).Return(mockBuilds, nil)
 
 	c := new(chi.Context)
 	c.URLParams.Add("owner", "octocat")
 	c.URLParams.Add("name", "hello-world")
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/?branch=develop", nil)
+	r := httptest.NewRequest("GET", "/?branch=develop&event=cron", nil)
 	r = r.WithContext(
 		context.WithValue(context.Background(), chi.RouteCtxKey, c),
 	)
@@ -177,7 +177,7 @@ func TestList_InternalError(t *testing.T) {
 	repos := mock.NewMockRepositoryStore(controller)
 	builds := mock.NewMockBuildStore(controller)
 	repos.EXPECT().FindName(gomock.Any(), gomock.Any(), mockRepo.Name).Return(mockRepo, nil)
-	builds.EXPECT().List(gomock.Any(), mockRepo.ID, 25, 0).Return(nil, errors.ErrNotFound)
+	builds.EXPECT().List(gomock.Any(), mockRepo.ID, "", "", 25, 0).Return(nil, errors.ErrNotFound)
 
 	c := new(chi.Context)
 	c.URLParams.Add("owner", "octocat")

--- a/mock/mock_gen.go
+++ b/mock/mock_gen.go
@@ -871,33 +871,18 @@ func (mr *MockBuildStoreMockRecorder) LatestPulls(arg0, arg1 interface{}) *gomoc
 }
 
 // List mocks base method.
-func (m *MockBuildStore) List(arg0 context.Context, arg1 int64, arg2, arg3 int) ([]*core.Build, error) {
+func (m *MockBuildStore) List(arg0 context.Context, arg1 int64, arg2, arg3 string, arg4, arg5 int) ([]*core.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "List", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].([]*core.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List.
-func (mr *MockBuildStoreMockRecorder) List(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBuildStoreMockRecorder) List(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockBuildStore)(nil).List), arg0, arg1, arg2, arg3)
-}
-
-// ListRef mocks base method.
-func (m *MockBuildStore) ListRef(arg0 context.Context, arg1 int64, arg2 string, arg3, arg4 int) ([]*core.Build, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRef", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].([]*core.Build)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRef indicates an expected call of ListRef.
-func (mr *MockBuildStoreMockRecorder) ListRef(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRef", reflect.TypeOf((*MockBuildStore)(nil).ListRef), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockBuildStore)(nil).List), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // Pending mocks base method.


### PR DESCRIPTION
A user can now pass `&event=cron|push|pull_request|...`

The WHERE condition is built like `('' = :build_event OR build_event = :build_event)` to allow the same query to be used when an event is specified and when it isn't (empty string)
As such, the `List` and `ListRef` methods were also merged into one using the same pattern

This is done to support https://github.com/drone/drone-ui/pull/356. I know that the support of filtering was riding on the implementation so this PR can serve as a discussion base
Let me know what you think of this

