### PR TITLE
bugfix: drone component failed to run and the process could not be terminated normally

### DIFF
--- a/cmd/drone-server/main.go
+++ b/cmd/drone-server/main.go
@@ -24,8 +24,8 @@ import (
 	"github.com/drone/drone/core"
 	"github.com/drone/drone/metric/sink"
 	"github.com/drone/drone/operator/runner"
-	"github.com/drone/drone/service/canceler/reaper"
 	"github.com/drone/drone/server"
+	"github.com/drone/drone/service/canceler/reaper"
 	"github.com/drone/drone/trigger/cron"
 	"github.com/drone/signal"
 
@@ -80,7 +80,7 @@ func main() {
 		logger.Fatalln("cannot bootstrap user account")
 	}
 
-	g := errgroup.Group{}
+	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		logrus.WithFields(
 			logrus.Fields{

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/unrolled/secure v0.0.0-20181022170031-4b6b7cf51606
 	go.starlark.net v0.0.0-20201118183435-e55f603d8c79
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/server/server.go
+++ b/server/server.go
@@ -54,11 +54,12 @@ func (s Server) ListenAndServe(ctx context.Context) error {
 }
 
 func (s Server) listenAndServe(ctx context.Context) error {
-	var g errgroup.Group
 	s1 := &http.Server{
 		Addr:    s.Addr,
 		Handler: s.Handler,
 	}
+
+	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		<-ctx.Done()
 
@@ -72,7 +73,6 @@ func (s Server) listenAndServe(ctx context.Context) error {
 }
 
 func (s Server) listenAndServeTLS(ctx context.Context) error {
-	var g errgroup.Group
 	s1 := &http.Server{
 		Addr:    ":http",
 		Handler: http.HandlerFunc(redirect),
@@ -81,6 +81,8 @@ func (s Server) listenAndServeTLS(ctx context.Context) error {
 		Addr:    ":https",
 		Handler: s.Handler,
 	}
+
+	g, ctx := errgroup.WithContext(ctx)
 	g.Go(s1.ListenAndServe)
 	g.Go(func() error {
 		return s2.ListenAndServeTLS(
@@ -108,8 +110,6 @@ func (s Server) listenAndServeTLS(ctx context.Context) error {
 }
 
 func (s Server) listenAndServeAcme(ctx context.Context) error {
-	var g errgroup.Group
-
 	c := cacheDir()
 	m := &autocert.Manager{
 		Email:      s.Email,
@@ -130,6 +130,8 @@ func (s Server) listenAndServeAcme(ctx context.Context) error {
 			MinVersion:     tls.VersionTLS12,
 		},
 	}
+
+	g, ctx := errgroup.WithContext(ctx)
 	g.Go(s1.ListenAndServe)
 	g.Go(func() error {
 		return s2.ListenAndServeTLS("", "")


### PR DESCRIPTION
When the `drone` starts, if one of the coroutines fails to execute, it should exit the program.

Because `errgroup` is used, the program will only exit when all the coroutines have ended.

The fastest way to test is to let `drone server` listen an occupied port.