### PR TITLE
Fix the bug of mapping the target field of DeployHook

### DIFF
--- a/service/hook/parser/parse.go
+++ b/service/hook/parser/parse.go
@@ -366,7 +366,7 @@ func (p *parser) Parse(req *http.Request, secretFunc func(string) string) (*core
 			After:        v.Ref.Sha,
 			Ref:          v.Ref.Path,
 			Source:       v.Ref.Name,
-			Target:       v.Ref.Name,
+			Target:       v.Target,
 			Author:       v.Sender.Login,
 			AuthorName:   v.Sender.Name,
 			AuthorEmail:  v.Sender.Email,


### PR DESCRIPTION
The Drone has a bug that changes the environment of GitHub deployment after a build when the trigger is promoted. It looks like the Drone maps the `target` field with the wrong field. 