### PR TITLE
Override drone build restart parameters

### DIFF
--- a/handler/api/repos/builds/retry.go
+++ b/handler/api/repos/builds/retry.go
@@ -89,6 +89,10 @@ func HandleRetry(
 			Params:       map[string]string{},
 		}
 
+		for key, value := range prev.Params {
+			hook.Params[key] = value
+		}
+		
 		for key, value := range r.URL.Query() {
 			if key == "access_token" {
 				continue
@@ -100,9 +104,6 @@ func HandleRetry(
 				continue
 			}
 			hook.Params[key] = value[0]
-		}
-		for key, value := range prev.Params {
-			hook.Params[key] = value
 		}
 
 		result, err := triggerer.Trigger(r.Context(), repo, hook)


### PR DESCRIPTION
`drone build restart` never override the custom parameters set by cli if they are already present in the build:

I.E.

```
$ drone build restart org/myrepo -p DOWNSTREAM_IMAGE_VER=test1 1
Number: 2
Status: pending
Event: push
[...]
```
In this case it works: `DOWNSTREAM_IMAGE_VER=test1`


```
$ drone build restart org/myrepo -p DOWNSTREAM_IMAGE_VER=test2 2
Number: 3
Status: pending
Event: push
[...]
```
In this case the variable test2 is ignored: `DOWNSTREAM_IMAGE_VER=test1`

More detail about the issue: https://discourse.drone.io/t/issue-with-params-using-downstream-plugin/10418
