### PR TITLE
Fix subrepositories by using the oldest trick in the book (url encode it when syncing)

### DIFF
--- a/service/syncer/syncer.go
+++ b/service/syncer/syncer.go
@@ -104,14 +104,7 @@ func (s *Synchronizer) Sync(ctx context.Context, user *core.User) (*core.Batch, 
 			return nil, err
 		}
 		for _, repo := range repos {
-			if strings.Count(repo.Slug, "/") > 1 {
-				if logrus.GetLevel() == logrus.TraceLevel {
-					logger.WithField("namespace", repo.Namespace).
-						WithField("name", repo.Name).
-						WithField("uid", repo.UID).
-						Traceln("syncer: skipping subrepositories")
-				}
-			} else if repo.Archived {
+			if repo.Archived {
 				if logrus.GetLevel() == logrus.TraceLevel {
 					logger.WithField("namespace", repo.Namespace).
 						WithField("name", repo.Name).
@@ -119,6 +112,15 @@ func (s *Synchronizer) Sync(ctx context.Context, user *core.User) (*core.Batch, 
 						Traceln("syncer: skipping archived repositories")
 				}
 			} else if s.match(repo) {
+				if strings.Count(repo.Slug, "/") > 1 {
+					repo.Namespace = strings.ReplaceAll(repo.Namespace, "/", "%2F")
+					if logrus.GetLevel() == logrus.TraceLevel {
+						logger.WithField("namespace", repo.Namespace).
+							WithField("name", repo.Name).
+							WithField("uid", repo.UID).
+							Traceln("syncer: modifying subrepositories path to url encoded")
+					}
+				}
 				remote[repo.UID] = repo
 				if logrus.GetLevel() == logrus.TraceLevel {
 					logger.WithField("namespace", repo.Namespace).

--- a/service/syncer/syncer_test.go
+++ b/service/syncer/syncer_test.go
@@ -390,7 +390,7 @@ func TestSync_BatchError(t *testing.T) {
 
 // this test verifies that sub-repositories are skipped. They
 // are unsupported by Drone and should not be ignored.
-func TestSync_SkipSubrepo(t *testing.T) {
+func TestSync_Subrepo(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
@@ -429,8 +429,21 @@ func TestSync_SkipSubrepo(t *testing.T) {
 		t.Error(err)
 	}
 
-	want := &core.Batch{}
-	if diff := cmp.Diff(got, want); len(diff) != 0 {
+	want := &core.Batch{
+		Insert: []*core.Repository{
+			{
+				UID:        "1",
+				Namespace:  "octocat",
+				Name:       "hello-world",
+				Slug:       "octocat/hello/world",
+				Visibility: "public",
+			},
+		},
+	}
+
+	ignore := cmpopts.IgnoreFields(core.Repository{},
+		"Synced", "Created", "Updated", "Version")
+	if diff := cmp.Diff(got, want, ignore); len(diff) != 0 {
 		t.Errorf(diff)
 	}
 }


### PR DESCRIPTION
When subrepositories are created on gitlab for instance, those are not shown.

## Intent
Fix subrepositories not showing in the UI and not being accessible via an URL

## Fix
Encode the namespace X/Y as X%2FY in the url.
As this is done on the syncing portion, this is only done once ever and will never be duplicated.
The url is thus addressable as the namespace route as a single element.
There is no collisions that could happen as even namespace with %2F would be invalid in any SCM (Choose a group path that does not start with a dash or end with a period. It can also contain alphanumeric characters and underscores. on gitlab). 

Collisions could happen on non standard SCM but as NONE are supported in your listing I don't see that as an issue (if it would be the case, a simple hash appending to the namespace would solve it)

