### PR TITLE
Skip check for runner architecture when item has arch="any"

### DIFF
--- a/scheduler/queue/queue.go
+++ b/scheduler/queue/queue.go
@@ -175,7 +175,7 @@ func (q *queue) signal(ctx context.Context) error {
 				if w.os != item.OS {
 					continue
 				}
-				if w.arch != item.Arch {
+				if item.Arch != "any" && w.arch != item.Arch {
 					continue
 				}
 				// if the pipeline defines a variant it must match


### PR DESCRIPTION
Allow using the special value "any" for the pipeline target platform architecture to bypass the checks for runner architecture when scheduling runs.

Use case: I have two servers, one amd64, one arm64, each with their own Drone runner instance connected to my Drone server. Some pipelines have no architecture dependent parts, for example scripts, as long as there is a docker image with the correct architecture that the runner can use.

If this is merged it will need a paragraph in the docs somewhere in the section about pipeline platform, but I didn't find the right place to edit that yet. 