### PR TITLE
Allow to override default env variables with .env file

### DIFF
--- a/cmd/drone-server/main.go
+++ b/cmd/drone-server/main.go
@@ -24,8 +24,8 @@ import (
 	"github.com/drone/drone/core"
 	"github.com/drone/drone/metric/sink"
 	"github.com/drone/drone/operator/runner"
-	"github.com/drone/drone/service/canceler/reaper"
 	"github.com/drone/drone/server"
+	"github.com/drone/drone/service/canceler/reaper"
 	"github.com/drone/drone/trigger/cron"
 	"github.com/drone/signal"
 
@@ -43,7 +43,7 @@ func main() {
 	flag.StringVar(&envfile, "env-file", ".env", "Read in a file of environment variables")
 	flag.Parse()
 
-	godotenv.Load(envfile)
+	godotenv.Overload(envfile)
 	config, err := config.Environ()
 	if err != nil {
 		logger := logrus.WithError(err)

--- a/cmd/drone-server/main.go
+++ b/cmd/drone-server/main.go
@@ -24,8 +24,8 @@ import (
 	"github.com/drone/drone/core"
 	"github.com/drone/drone/metric/sink"
 	"github.com/drone/drone/operator/runner"
-	"github.com/drone/drone/server"
 	"github.com/drone/drone/service/canceler/reaper"
+	"github.com/drone/drone/server"
 	"github.com/drone/drone/trigger/cron"
 	"github.com/drone/signal"
 


### PR DESCRIPTION
The [`godotenv.Load`](https://pkg.go.dev/github.com/joho/godotenv#Load) method does not overload the ENV variable if it is already present. This is a problem if you want to use `--env-file` to provide any settings with default values in Dockerfile. This means, that it's not possible to set `DRONE_DATABASE_SECRET` within .env file (trying to achieve the technique described [here](https://github.com/gesellix/drone-stack/blob/master/docker-stack.yml)).

In the case of deploying the Drone, I'm sure that using [`godotenv.Overload`](https://pkg.go.dev/github.com/joho/godotenv#Overload) is preferable, because this allows to keep the database password private with docker secrets.

---

My current workaround is using `entrypoint` to unset env variables:

``` yaml
entrypoint:
  - /bin/sh
  - -c
  - |
    set -e
    unset DRONE_DATABASE_DATASOURCE
    set -- /bin/drone-server "$$@"
    exec "$$@"
command:
  - /bin/drone-server
  - --env-file=/drone.secret.env
```