### PR TITLE
Multi Templates

### DIFF
--- a/plugin/converter/template.go
+++ b/plugin/converter/template.go
@@ -73,7 +73,7 @@ func (p *templatePlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*c
 
 	buf := new(bytes.Buffer)
 	rawTemplates := strings.Split(req.Config.Data, "---")
-	for _, rawTemplate := range rawTemplates {
+	for idx, rawTemplate := range rawTemplates {
 		// map to templateArgs
 		var templateArgs core.TemplateArgs
 		err := yaml.Unmarshal([]byte(rawTemplate), &templateArgs)
@@ -107,7 +107,7 @@ func (p *templatePlugin) Convert(ctx context.Context, req *core.ConvertArgs) (*c
 		}
 
 		ext := filepath.Ext(templateArgs.Load)
-		if ext == ".yml" || ext == ".yaml" {
+		if ext == ".yml" || ext == ".yaml" && idx < len(rawTemplates)-1 {
 			buf.WriteString("\n")
 			buf.WriteString("---")
 			buf.WriteString("\n")

--- a/plugin/converter/template_test.go
+++ b/plugin/converter/template_test.go
@@ -551,3 +551,196 @@ func TestTemplatePluginConvertYamlWithComment(t *testing.T) {
 		t.Errorf("Want %q got %q", want, got)
 	}
 }
+
+func TestTemplatePluginConvertYamlWithExtraPipeline(t *testing.T) {
+	templateArgs, err := ioutil.ReadFile("testdata/yaml.template.with-extra-pipeline.yml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	req := &core.ConvertArgs{
+		Build: &core.Build{
+			After: "3d21ec53a331a6f037a91c368710b99387d012c1",
+		},
+		Repo: &core.Repository{
+			Slug:      "octocat/hello-world",
+			Config:    ".drone.yml",
+			Namespace: "octocat",
+		},
+		Config: &core.Config{
+			Data: string(templateArgs),
+		},
+	}
+
+	beforeInput, err := ioutil.ReadFile("testdata/yaml.input.yml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	after, err := ioutil.ReadFile("testdata/yaml.input.with-extra-pipeline.golden")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	template := &core.Template{
+		Name:      "plugin.yaml",
+		Data:      string(beforeInput),
+		Namespace: "octocat",
+	}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	templates := mock.NewMockTemplateStore(controller)
+	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil)
+
+	plugin := Template(templates, 0, 0)
+	config, err := plugin.Convert(noContext, req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if config == nil {
+		t.Error("Want non-nil configuration")
+		return
+	}
+
+	if want, got := config.Data, string(after); want != got {
+		t.Errorf("Want %q got %q", want, got)
+	}
+}
+
+func TestTemplatePluginConvertYamlWithDoubleTemplate(t *testing.T) {
+	templateArgs, err := ioutil.ReadFile("testdata/yaml.two.templates.yml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	req := &core.ConvertArgs{
+		Build: &core.Build{
+			After: "3d21ec53a331a6f037a91c368710b99387d012c1",
+		},
+		Repo: &core.Repository{
+			Slug:      "octocat/hello-world",
+			Config:    ".drone.yml",
+			Namespace: "octocat",
+		},
+		Config: &core.Config{
+			Data: string(templateArgs),
+		},
+	}
+
+	beforeInput, err := ioutil.ReadFile("testdata/yaml.input-with-name.yml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	after, err := ioutil.ReadFile("testdata/yaml.input.two.golden")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	template := &core.Template{
+		Name:      "plugin.yaml",
+		Data:      string(beforeInput),
+		Namespace: "octocat",
+	}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	templates := mock.NewMockTemplateStore(controller)
+	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil).Times(2)
+
+	plugin := Template(templates, 0, 0)
+	config, err := plugin.Convert(noContext, req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if config == nil {
+		t.Error("Want non-nil configuration")
+		return
+	}
+
+	if want, got := config.Data, string(after); want != got {
+		t.Errorf("Want %q got %q", want, got)
+	}
+}
+
+func TestTemplatePluginConvertJsonnetWithFunction(t *testing.T) {
+	templateArgs, err := ioutil.ReadFile("testdata/go.template.yml")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	req := &core.ConvertArgs{
+		Build: &core.Build{
+			After: "3d21ec53a331a6f037a91c368710b99387d012c1",
+		},
+		Repo: &core.Repository{
+			Slug:      "octocat/hello-world",
+			Config:    ".drone.yml",
+			Namespace: "octocat",
+		},
+		Config: &core.Config{
+			Data: string(templateArgs),
+		},
+	}
+
+	beforeInput, err := ioutil.ReadFile("testdata/go-input.jsonnet")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	after, err := ioutil.ReadFile("testdata/go-input.jsonnet.golden")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	template := &core.Template{
+		Name:      "go-input.jsonnet",
+		Data:      string(beforeInput),
+		Namespace: "octocat",
+	}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	templates := mock.NewMockTemplateStore(controller)
+	templates.EXPECT().FindName(gomock.Any(), template.Name, req.Repo.Namespace).Return(template, nil).Times(2)
+
+	plugin := Template(templates, 0, 0)
+	config, err := plugin.Convert(noContext, req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if config == nil {
+		t.Error("Want non-nil configuration")
+		return
+	}
+
+	want := string(after)
+	// on windows line endings are \r\n, lets change them to linux for comparison
+	if runtime.GOOS == "windows" {
+		want = strings.Replace(want, "\r\n", "\n", -1)
+	}
+
+	got := config.Data
+	if want != got {
+		t.Errorf("Want %q got %q", want, got)
+	}
+}

--- a/plugin/converter/testdata/go-input.jsonnet
+++ b/plugin/converter/testdata/go-input.jsonnet
@@ -1,0 +1,75 @@
+local goImage = if std.extVar("input.goImage") != "" then std.extVar("input.goImage") else "golang:1.18";
+local pipeline_name = if std.extVar("input.pipelineName") != "" then std.extVar("input.pipelineName") else "development";
+
+local pipeline(name) = {
+  kind: 'pipeline',
+  type: 'docker',
+  name: name,
+  withTrigger(trigger):: self + {
+    trigger: trigger,
+  },
+  withVolumes(volumes):: self + {
+    volumes: volumes,
+  },
+  withServices(services):: self + {
+    services: services,
+  },
+  withSteps(steps):: self + {
+    steps: steps,
+  },
+};
+
+local step(name, image) = {
+  name: name,
+  image: image,
+  withCommands(commands):: self + {
+    commands: commands,
+  },
+  withWhen(when):: self + {
+    when: when,
+  },
+  withVolumes(volumes):: self + {
+    volumes: volumes,
+  },
+  withEnvs(envs):: self + {
+    environment: envs,
+  },
+  withDeps(deps):: self + {
+    depends_on: deps,
+  },
+  withSettings(settings):: self + {
+    settings: settings,
+  },
+};
+
+local golint = step(
+  name='golint',
+  image='golangci/golangci-lint:v1.52.0-alpine',
+).withCommands(['golangci-lint run']);
+
+local gotest = step(
+  name='gotest',
+  image=goImage,
+).withCommands([
+  'go test -v ./...',
+]);
+
+local volumes = [
+  { name: 'docker', host: { path: '/var/run/docker.sock' } },
+];
+
+local development =
+  pipeline(pipeline_name)
+  .withTrigger({
+    branch: ['dev'],
+    event: ['pull_request', 'push'],
+  })
+  .withVolumes(volumes)
+  .withSteps([
+      golint,
+      gotest,
+  ]);
+
+[
+  development,
+]

--- a/plugin/converter/testdata/go-input.jsonnet.golden
+++ b/plugin/converter/testdata/go-input.jsonnet.golden
@@ -1,0 +1,78 @@
+---
+{
+   "kind": "pipeline",
+   "name": "template-1",
+   "steps": [
+      {
+         "commands": [
+            "golangci-lint run"
+         ],
+         "image": "golangci/golangci-lint:v1.52.0-alpine",
+         "name": "golint"
+      },
+      {
+         "commands": [
+            "go test -v ./..."
+         ],
+         "image": "golang:1.19",
+         "name": "gotest"
+      }
+   ],
+   "trigger": {
+      "branch": [
+         "dev"
+      ],
+      "event": [
+         "pull_request",
+         "push"
+      ]
+   },
+   "type": "docker",
+   "volumes": [
+      {
+         "host": {
+            "path": "/var/run/docker.sock"
+         },
+         "name": "docker"
+      }
+   ]
+}
+---
+{
+   "kind": "pipeline",
+   "name": "template-2",
+   "steps": [
+      {
+         "commands": [
+            "golangci-lint run"
+         ],
+         "image": "golangci/golangci-lint:v1.52.0-alpine",
+         "name": "golint"
+      },
+      {
+         "commands": [
+            "go test -v ./..."
+         ],
+         "image": "golang:1.19",
+         "name": "gotest"
+      }
+   ],
+   "trigger": {
+      "branch": [
+         "dev"
+      ],
+      "event": [
+         "pull_request",
+         "push"
+      ]
+   },
+   "type": "docker",
+   "volumes": [
+      {
+         "host": {
+            "path": "/var/run/docker.sock"
+         },
+         "name": "docker"
+      }
+   ]
+}

--- a/plugin/converter/testdata/go.template.yml
+++ b/plugin/converter/testdata/go.template.yml
@@ -1,0 +1,12 @@
+kind: template
+load: go-input.jsonnet
+data:
+  goImage: "golang:1.19"
+  pipelineName: "template-1"
+
+---
+kind: template
+load: go-input.jsonnet
+data:
+  goImage: "golang:1.19"
+  pipelineName: "template-2"

--- a/plugin/converter/testdata/input.with-two-pipeline.yaml
+++ b/plugin/converter/testdata/input.with-two-pipeline.yaml
@@ -1,0 +1,7 @@
+kind: template
+load: with-two-pipeline.template.yaml
+data:
+  chart_name: test
+  chart_version: 0.1.1
+  service_name: test-service-name
+  jdk_image: openjdk-11

--- a/plugin/converter/testdata/with-two-pipeline.template.yaml
+++ b/plugin/converter/testdata/with-two-pipeline.template.yaml
@@ -1,0 +1,72 @@
+kind: pipeline
+name: {{ .input.service_name }}
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+anchors:
+  - &mvn-step
+    image: {{ .input.jdk_image }}
+    privileged: true
+    volumes:
+      - name: m2-cache
+        path: /root/.m2
+      - name: docker
+        path: /var/run/docker.sock
+    environment:
+      SONAR_PROJECT_NAME: {{ .input.service_name }}
+      GIT_PUSH_SSH_KEY:
+        from_secret: git_ssh_key
+
+steps:
+  - name: build-and-test
+    <<: *mvn-step
+    commands:
+      - mvn package -U -B
+    when:
+      branch:
+        exclude:
+          - master
+---
+
+kind: pipeline
+name: {{ .input.service_name }}-um
+
+trigger:
+  event:
+    - promote
+  target:
+    - um-prod
+    - um-dev
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+anchors:
+  - &mvn-step
+    image: {{ .input.jdk_image}}
+    privileged: true
+    volumes:
+      - name: m2-cache
+        path: /root/.m2
+      - name: docker
+        path: /var/run/docker.sock
+    environment:
+      SONAR_PROJECT_NAME: {{ .input.service_name }}
+      GIT_PUSH_SSH_KEY:
+        from_secret: git_ssh_key
+
+steps:
+  - name: build-and-test
+    <<: *mvn-step
+    commands:
+      - mvn package -U -B

--- a/plugin/converter/testdata/with-two-pipelone.yaml.golden
+++ b/plugin/converter/testdata/with-two-pipelone.yaml.golden
@@ -1,0 +1,72 @@
+kind: pipeline
+name: test-service-name
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+anchors:
+  - &mvn-step
+    image: openjdk-11
+    privileged: true
+    volumes:
+      - name: m2-cache
+        path: /root/.m2
+      - name: docker
+        path: /var/run/docker.sock
+    environment:
+      SONAR_PROJECT_NAME: test-service-name
+      GIT_PUSH_SSH_KEY:
+        from_secret: git_ssh_key
+
+steps:
+  - name: build-and-test
+    <<: *mvn-step
+    commands:
+      - mvn package -U -B
+    when:
+      branch:
+        exclude:
+          - master
+---
+
+kind: pipeline
+name: test-service-name-um
+
+trigger:
+  event:
+    - promote
+  target:
+    - um-prod
+    - um-dev
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+
+anchors:
+  - &mvn-step
+    image: openjdk-11
+    privileged: true
+    volumes:
+      - name: m2-cache
+        path: /root/.m2
+      - name: docker
+        path: /var/run/docker.sock
+    environment:
+      SONAR_PROJECT_NAME: test-service-name
+      GIT_PUSH_SSH_KEY:
+        from_secret: git_ssh_key
+
+steps:
+  - name: build-and-test
+    <<: *mvn-step
+    commands:
+      - mvn package -U -B

--- a/plugin/converter/testdata/yaml.input-with-name.yml
+++ b/plugin/converter/testdata/yaml.input-with-name.yml
@@ -1,0 +1,8 @@
+kind: pipeline
+type: docker
+name: {{ .input.name }}
+steps:
+  - name:  {{ upper .input.stepName }}
+    image: {{ .input.image }}
+    commands:
+      - {{ .input.commands }}

--- a/plugin/converter/testdata/yaml.input.golden
+++ b/plugin/converter/testdata/yaml.input.golden
@@ -6,3 +6,4 @@ steps:
     image: my_image
     commands:
       - my_command
+---

--- a/plugin/converter/testdata/yaml.input.golden
+++ b/plugin/converter/testdata/yaml.input.golden
@@ -6,4 +6,3 @@ steps:
     image: my_image
     commands:
       - my_command
----

--- a/plugin/converter/testdata/yaml.input.two.golden
+++ b/plugin/converter/testdata/yaml.input.two.golden
@@ -15,4 +15,3 @@ steps:
     image: my_image
     commands:
       - my_command
----

--- a/plugin/converter/testdata/yaml.input.two.golden
+++ b/plugin/converter/testdata/yaml.input.two.golden
@@ -1,0 +1,18 @@
+kind: pipeline
+type: docker
+name: with_template_1
+steps:
+  - name:  MY_STEP
+    image: my_image
+    commands:
+      - my_command
+---
+kind: pipeline
+type: docker
+name: with_template_2
+steps:
+  - name:  MY_STEP
+    image: my_image
+    commands:
+      - my_command
+---

--- a/plugin/converter/testdata/yaml.input.with-extra-pipeline.golden
+++ b/plugin/converter/testdata/yaml.input.with-extra-pipeline.golden
@@ -1,0 +1,18 @@
+kind: pipeline
+type: docker
+name: defaults
+steps:
+  - name:  MY_STEP
+    image: my_image
+    commands:
+      - my_command
+---
+
+kind: pipeline
+type: docker
+name: extra-pipeline
+steps:
+  - name:  extra_my_step
+    image: extra_image
+    commands:
+      - echo "extra_command"

--- a/plugin/converter/testdata/yaml.template.with-extra-pipeline.yml
+++ b/plugin/converter/testdata/yaml.template.with-extra-pipeline.yml
@@ -1,0 +1,17 @@
+# this is a comment
+kind: template
+load: plugin.yaml
+data:
+  stepName: my_step
+  image: my_image
+  commands: my_command
+
+---
+kind: pipeline
+type: docker
+name: extra-pipeline
+steps:
+  - name:  extra_my_step
+    image: extra_image
+    commands:
+      - echo "extra_command"

--- a/plugin/converter/testdata/yaml.two.templates.yml
+++ b/plugin/converter/testdata/yaml.two.templates.yml
@@ -1,0 +1,16 @@
+kind: template
+load: plugin.yaml
+data:
+  stepName: my_step
+  image: my_image
+  commands: my_command
+  name: with_template_1
+
+---
+kind: template
+load: plugin.yaml
+data:
+  stepName: my_step
+  image: my_image
+  commands: my_command
+  name: with_template_2


### PR DESCRIPTION
This is a new feature to Drone CI, allowing the use of multi templates. With this enhancement, users will have the capability to define and utilize multiple templates within their CI/CD pipelines. This is a significant addition that enhances the flexibility and extensibility of Drone CI, enabling users to streamline their pipeline definitions and improve overall workflow management.

### Changes Made
- Implemented the multi template functionality, enabling users to define and utilize multiple templates in their pipeline configuration.

### Benefits
- **Enhanced Reusability:** Multi templates empower users to encapsulate and reuse common pipeline segments across different projects and workflows, reducing redundancy and improving maintainability.
- **Customization:** Users can mix and match templates to tailor their CI/CD pipelines according to project-specific requirements, optimizing their workflows.

### Examples
template

```yaml
kind: pipeline
type: docker
name: {{ .input.name }}
steps:
  - name:  {{ upper .input.stepName }}
    image: {{ .input.image }}
    commands:
      - {{ .input.commands }}
```

drone.yaml
```yaml

kind: template
load: plugin.yaml
data:
  stepName: my_step
  image: my_image
  commands: my_command

---
kind: pipeline
type: docker
name: extra-pipeline
steps:
  - name:  extra_my_step
    image: extra_image
    commands:
      - echo "extra_command"

```
result pipeline 

```yaml
kind: pipeline
type: docker
name: defaults
steps:
  - name:  MY_STEP
    image: my_image
    commands:
      - my_command
---

kind: pipeline
type: docker
name: extra-pipeline
steps:
  - name:  extra_my_step
    image: extra_image
    commands:
      - echo "extra_command"
```