### PR TITLE
enable the settings link in order to delete empty repository

### DIFF
--- a/web/src/hooks/useDisableCodeMainLinks.ts
+++ b/web/src/hooks/useDisableCodeMainLinks.ts
@@ -22,7 +22,7 @@ export function useDisableCodeMainLinks(disabled: boolean) {
       const nav = document.querySelectorAll('[data-code-repo-section]')
 
       nav?.forEach(element => {
-        if (element.getAttribute('data-code-repo-section') !== 'files') {
+        if (!['files', 'settings'].includes(<string>element.getAttribute('data-code-repo-section'))) {
           element.setAttribute('aria-disabled', 'true')
         }
       })


### PR DESCRIPTION
After create or import an empty repository, only the `files` link is enabled.
if the user wants to delete it, he must initiate a commit to make it no longer empty, and then he can enter the settings page to delete it.

Can we allow users to enter the settings page of an empty repository to delete it directly?