### PR TITLE
fix: [CI-11840]: Added env variable to control the event of inbound w…

### DIFF
--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -80,14 +80,14 @@ type (
 		Yaml         Yaml
 
 		// Remote configurations
-		Bitbucket            Bitbucket
-		Gitea                Gitea
-		Github               Github
-		GitLab               GitLab
-		Gogs                 Gogs
-		Stash                Stash
-		Gitee                Gitee
-		InboundWebhookEvents InboundWebhookEvents
+		Bitbucket       Bitbucket
+		Gitea           Gitea
+		Github          Github
+		GitLab          GitLab
+		Gogs            Gogs
+		Stash           Stash
+		Gitee           Gitee
+		IncomingWebhook IncomingWebhook
 	}
 
 	// Cloning provides the cloning configuration.
@@ -445,7 +445,7 @@ type (
 		ReferrerPolicy        string            `envconfig:"DRONE_HTTP_REFERRER_POLICY"`
 	}
 
-	InboundWebhookEvents struct {
+	IncomingWebhook struct {
 		Events []string `envconfig:"DRONE_INCOMING_WEBHOOK_EVENTS" default:"branch,deployment,push,tag,pull_request"`
 	}
 )

--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -80,13 +80,14 @@ type (
 		Yaml         Yaml
 
 		// Remote configurations
-		Bitbucket Bitbucket
-		Gitea     Gitea
-		Github    Github
-		GitLab    GitLab
-		Gogs      Gogs
-		Stash     Stash
-		Gitee     Gitee
+		Bitbucket            Bitbucket
+		Gitea                Gitea
+		Github               Github
+		GitLab               GitLab
+		Gogs                 Gogs
+		Stash                Stash
+		Gitee                Gitee
+		InboundWebhookEvents InboundWebhookEvents
 	}
 
 	// Cloning provides the cloning configuration.
@@ -300,7 +301,7 @@ type (
 	}
 
 	// Webhook provides the webhook configuration.
-	Webhook struct {
+	Webhook struct { //This seems to be outbound
 		Events     []string `envconfig:"DRONE_WEBHOOK_EVENTS"`
 		Endpoint   []string `envconfig:"DRONE_WEBHOOK_ENDPOINT"`
 		Secret     string   `envconfig:"DRONE_WEBHOOK_SECRET"`
@@ -442,6 +443,10 @@ type (
 		ContentTypeNosniff    bool              `envconfig:"DRONE_HTTP_CONTENT_TYPE_NO_SNIFF"`
 		ContentSecurityPolicy string            `envconfig:"DRONE_HTTP_CONTENT_SECURITY_POLICY"`
 		ReferrerPolicy        string            `envconfig:"DRONE_HTTP_REFERRER_POLICY"`
+	}
+
+	InboundWebhookEvents struct {
+		Events []string `envconfig:"DRONE_INCOMING_WEBHOOK_EVENTS" default:"branch,deployment,push,tag,pull_request"`
 	}
 )
 

--- a/cmd/drone-server/config/config.go
+++ b/cmd/drone-server/config/config.go
@@ -301,7 +301,7 @@ type (
 	}
 
 	// Webhook provides the webhook configuration.
-	Webhook struct { //This seems to be outbound
+	Webhook struct {
 		Events     []string `envconfig:"DRONE_WEBHOOK_EVENTS"`
 		Endpoint   []string `envconfig:"DRONE_WEBHOOK_ENDPOINT"`
 		Secret     string   `envconfig:"DRONE_WEBHOOK_SECRET"`

--- a/cmd/drone-server/inject_service.go
+++ b/cmd/drone-server/inject_service.go
@@ -85,7 +85,7 @@ func provideContentService(client *scm.Client, renewer core.Renewer) core.FileSe
 // provideHookService is a Wire provider function that returns a
 // hook service based on the environment configuration.
 func provideHookService(client *scm.Client, renewer core.Renewer, config config.Config) core.HookService {
-	return hook.New(client, config.Proxy.Addr, renewer)
+	return hook.New(client, config.Proxy.Addr, renewer, config.InboundWebhookEvents.Events)
 }
 
 // provideNetrcService is a Wire provider function that returns

--- a/cmd/drone-server/inject_service.go
+++ b/cmd/drone-server/inject_service.go
@@ -85,7 +85,7 @@ func provideContentService(client *scm.Client, renewer core.Renewer) core.FileSe
 // provideHookService is a Wire provider function that returns a
 // hook service based on the environment configuration.
 func provideHookService(client *scm.Client, renewer core.Renewer, config config.Config) core.HookService {
-	return hook.New(client, config.Proxy.Addr, renewer, config.InboundWebhookEvents.Events)
+	return hook.New(client, config.Proxy.Addr, renewer, config.IncomingWebhook.Events)
 }
 
 // provideNetrcService is a Wire provider function that returns

--- a/service/hook/hook.go
+++ b/service/hook/hook.go
@@ -23,14 +23,15 @@ import (
 )
 
 // New returns a new HookService.
-func New(client *scm.Client, addr string, renew core.Renewer) core.HookService {
-	return &service{client: client, addr: addr, renew: renew}
+func New(client *scm.Client, addr string, renew core.Renewer, events []string) core.HookService {
+	return &service{client: client, addr: addr, renew: renew, events: events}
 }
 
 type service struct {
 	renew  core.Renewer
 	client *scm.Client
 	addr   string
+	events []string
 }
 
 func (s *service) Create(ctx context.Context, user *core.User, repo *core.Repository) error {
@@ -38,6 +39,13 @@ func (s *service) Create(ctx context.Context, user *core.User, repo *core.Reposi
 	if err != nil {
 		return err
 	}
+
+	var eventsMap map[string]bool
+	eventsMap = make(map[string]bool)
+	for _, event := range s.events {
+		eventsMap[event] = true
+	}
+
 	ctx = context.WithValue(ctx, scm.TokenKey{}, &scm.Token{
 		Token:   user.Token,
 		Refresh: user.Refresh,
@@ -48,11 +56,11 @@ func (s *service) Create(ctx context.Context, user *core.User, repo *core.Reposi
 		Target: s.addr + "/hook",
 		Secret: repo.Signer,
 		Events: scm.HookEvents{
-			Branch:      true,
-			Deployment:  true,
-			PullRequest: true,
-			Push:        true,
-			Tag:         true,
+			Branch:      eventsMap["branch"],
+			Deployment:  eventsMap["deployment"],
+			PullRequest: eventsMap["pull_request"],
+			Push:        eventsMap["push"],
+			Tag:         eventsMap["tag"],
 		},
 	}
 	return replaceHook(ctx, s.client, repo.Slug, hook)

--- a/service/hook/hook.go
+++ b/service/hook/hook.go
@@ -40,8 +40,7 @@ func (s *service) Create(ctx context.Context, user *core.User, repo *core.Reposi
 		return err
 	}
 
-	var eventsMap map[string]bool
-	eventsMap = make(map[string]bool)
+	eventsMap := make(map[string]bool)
 	for _, event := range s.events {
 		eventsMap[event] = true
 	}

--- a/service/hook/hook_test.go
+++ b/service/hook/hook_test.go
@@ -54,7 +54,7 @@ func TestCreate(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepos
 
-	service := New(client, "https://drone.company.com", mockRenewer)
+	service := New(client, "https://drone.company.com", mockRenewer, []string{})
 	err := service.Create(noContext, mockUser, mockRepo)
 	if err != nil {
 		t.Error(err)
@@ -70,7 +70,7 @@ func TestCreate_RenewErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, "https://drone.company.com", mockRenewer)
+	service := New(nil, "https://drone.company.com", mockRenewer, []string{})
 	err := service.Create(noContext, mockUser, nil)
 	if err != scm.ErrNotAuthorized {
 		t.Errorf("Want not authorized error, got %v", err)
@@ -106,7 +106,7 @@ func TestDelete(t *testing.T) {
 	client := new(scm.Client)
 	client.Repositories = mockRepos
 
-	service := New(client, "https://drone.company.com", mockRenewer)
+	service := New(client, "https://drone.company.com", mockRenewer, []string{})
 	err := service.Delete(noContext, mockUser, mockRepo)
 	if err != nil {
 		t.Error(err)
@@ -122,7 +122,7 @@ func TestDelete_RenewErr(t *testing.T) {
 	mockRenewer := mock.NewMockRenewer(controller)
 	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(scm.ErrNotAuthorized)
 
-	service := New(nil, "https://drone.company.com", mockRenewer)
+	service := New(nil, "https://drone.company.com", mockRenewer, []string{})
 	err := service.Delete(noContext, mockUser, nil)
 	if err != scm.ErrNotAuthorized {
 		t.Errorf("Want not authorized error, got %v", err)

--- a/service/hook/hook_test.go
+++ b/service/hook/hook_test.go
@@ -50,11 +50,52 @@ func TestCreate(t *testing.T) {
 	mockRepos := mockscm.NewMockRepositoryService(controller)
 	mockRepos.EXPECT().ListHooks(gomock.Any(), "octocat/hello-world", gomock.Any()).Return(mockHooks, nil, nil)
 	mockRepos.EXPECT().CreateHook(gomock.Any(), "octocat/hello-world", hook).Return(nil, nil, nil)
-
 	client := new(scm.Client)
 	client.Repositories = mockRepos
 
-	service := New(client, "https://drone.company.com", mockRenewer, []string{})
+	service := New(client, "https://drone.company.com", mockRenewer, []string{"branch", "deployment", "push", "tag", "pull_request"})
+	err := service.Create(noContext, mockUser, mockRepo)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCreateWithLimitedEvents(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	mockUser := &core.User{}
+	mockHooks := []*scm.Hook{}
+	mockRepo := &core.Repository{
+		Namespace: "octocat",
+		Name:      "hello-world",
+		Slug:      "octocat/hello-world",
+		Signer:    "abc123",
+	}
+
+	hook := &scm.HookInput{
+		Name:   "drone",
+		Target: "https://drone.company.com/hook",
+		Secret: "abc123",
+		Events: scm.HookEvents{
+			Branch:      false,
+			Deployment:  true,
+			PullRequest: true,
+			Push:        false,
+			Tag:         true,
+		},
+	}
+
+	mockRenewer := mock.NewMockRenewer(controller)
+	mockRenewer.EXPECT().Renew(gomock.Any(), mockUser, false).Return(nil)
+
+	mockRepos := mockscm.NewMockRepositoryService(controller)
+	mockRepos.EXPECT().ListHooks(gomock.Any(), "octocat/hello-world", gomock.Any()).Return(mockHooks, nil, nil)
+	mockRepos.EXPECT().CreateHook(gomock.Any(), "octocat/hello-world", hook).Return(nil, nil, nil)
+	client := new(scm.Client)
+	client.Repositories = mockRepos
+
+	service := New(client, "https://drone.company.com", mockRenewer, []string{"deployment", "tag", "pull_request"})
 	err := service.Create(noContext, mockUser, mockRepo)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Have added the env var "DRONE_INCOMING_WEBHOOK_EVENTS" (of type list of string) to control the event in case of incoming webhook. If no such env variable is provided then it will fallback to default behaviour. Below are the test cases


-  Case 1: When no env variable "DRONE_INCOMING_WEBHOOK_EVENTS" is present.

https://github.com/harness/gitness/assets/139750384/ad228d61-2608-4756-abaa-b3397eba1fb7

-  Case 2: When Deployment event is missing from env var.

https://github.com/harness/gitness/assets/139750384/0faf2afc-9e0b-42f1-9327-8dc674ed112d

- Case 3: When Deployment, pull_request events are missing from env var.

https://github.com/harness/gitness/assets/139750384/29f40107-4b7a-4eae-afa8-464d78662e8b

- Case 4: When Deployment and push events are only present in env var.

https://github.com/harness/gitness/assets/139750384/b6cdec79-20bb-4d56-8fd0-f72cb9e57a8e


Tested with few more combinations as well.
